### PR TITLE
 [TCK] removed unused import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <artifactId>javaconfig-parent</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <description>JSR-382 Configuraiton API for Java v1.0 - Parent POM</description>
+    <description>JSR-382 Configuration API for Java v1.0 - Parent POM</description>
 
     <url>https://jcp.org/en/jsr/detail?id=382</url>
 

--- a/tck/src/main/java/org/eclipse/configjsr/converters/Donald.java
+++ b/tck/src/main/java/org/eclipse/configjsr/converters/Donald.java
@@ -19,8 +19,6 @@
  */
 package org.eclipse.configjsr.converters;
 
-import java.util.Objects;
-
 /**
  * Class, which is converted using a Lambda based converter.
  * @author <a href="mailto:anatole@apache.org">Anatole Tresch</a>


### PR DESCRIPTION
The checkstyle maven plugin fails and prevents to build the TCK: https://ci.wildfly.org/viewLog.html?buildId=82374&buildTypeId=MicroProfileJsr_ConfigJSR_Build&tab=buildLog