### PR TITLE
withConverter() priority + TCK

### DIFF
--- a/api/src/main/java/javax/config/spi/ConfigBuilder.java
+++ b/api/src/main/java/javax/config/spi/ConfigBuilder.java
@@ -86,7 +86,7 @@ public interface ConfigBuilder {
      * Add the specified {@link Converter}.
      * This method uses reflection to determine what type the converter is for.
      * When using lambda expressions for custom converters you should use
-     * {@link #withConverter(Class, Converter)} and pass the target type explicitly
+     * {@link #withConverter(Class, int, Converter)} and pass the target type explicitly
      * as lambda expressions do not offer enough type information to the reflection API.
      *
      * @param converters the converters
@@ -99,10 +99,13 @@ public interface ConfigBuilder {
      * This method does not rely on reflection to determine what type the converter is for
      * therefore also lambda expressions can be used.
      *
-     * @param converter the converter, not null
+     * @param type the Class of type to convert
+     * @param priority the priority of the converter (custom converters have a default priority of 100).
+     * @param converter the converter (can not be {@code null})
+     * @param <T> the type to convert
      * @return the ConfigBuilder with the added converters
      */
-    <T> ConfigBuilder withConverter(Class<T> type, Converter<T> converter);
+    <T> ConfigBuilder withConverter(Class<T> type, int priority, Converter<T> converter);
 
     /**
      * Build the {@link Config} object.

--- a/tck/src/main/java/org/eclipse/configjsr/converters/Donald.java
+++ b/tck/src/main/java/org/eclipse/configjsr/converters/Donald.java
@@ -26,9 +26,12 @@ package org.eclipse.configjsr.converters;
 public class Donald {
 
     private String name;
+    private boolean bool;
 
-    private Donald(String name) {
+    private Donald(String name, boolean bool) {
+
         this.name = name;
+        this.bool = bool;
     }
 
 
@@ -38,7 +41,7 @@ public class Donald {
      * @return a new instance, never null.
      */
     public static Donald iLikeDonald(String name){
-        return new Donald(name);
+        return new Donald(name, true);
     }
 
     public String getName(){

--- a/tck/src/main/java/org/eclipse/configjsr/converters/UpperCaseDuckConverter.java
+++ b/tck/src/main/java/org/eclipse/configjsr/converters/UpperCaseDuckConverter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.configjsr.converters;
+
+import javax.annotation.Priority;
+import javax.config.spi.Converter;
+
+/**
+ * Always create a duck with an upper case name
+ */
+@Priority(101)
+public class UpperCaseDuckConverter implements Converter<Duck>{
+    @Override
+    public Duck convert(String value) {
+        return new Duck(value.toUpperCase());
+    }
+}


### PR DESCRIPTION
# [API] add withConverter(Class<T>, int, Converter<T>)  …

This method allows to specify a priority for the converter.
The previous method withConverter(Class<T>, Converter<T>) is now a
default method with a default priority of 100.

Add ConverterTest#testDonaldConversionWithMultipleLambdaConverters to
check that priority is taken into account when using these methods.

# [TCK] make Donald constructor not usable for implicit conversion

# [TCK] add test for converter priority

if a type has many converters, the one with the highest priority will be used