### PR TITLE
refs: #27 handle AutoCloseable Converters and ConfigSources

### DIFF
--- a/api/src/main/java/javax/config/spi/ConfigSource.java
+++ b/api/src/main/java/javax/config/spi/ConfigSource.java
@@ -56,6 +56,10 @@ import java.util.Set;
  * <p>Adding a dynamic amount of custom config sources can be done programmatically via
  * {@link javax.config.spi.ConfigSourceProvider}.
  *
+ *  <p>If a ConfigSource implements the {@link AutoCloseable} interface
+ *  then the {@link AutoCloseable#close()} method will be called when
+ *  the underlying {@link javax.config.Config} is being released.
+ *
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
  * @author <a href="mailto:gpetracek@apache.org">Gerhard Petracek</a>
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>

--- a/api/src/main/java/javax/config/spi/Converter.java
+++ b/api/src/main/java/javax/config/spi/Converter.java
@@ -104,6 +104,12 @@ package javax.config.spi;
  *  <p>
  *  myPets will be "dog", "cat", "dog,cat"
  *
+ *  <h3>Cleanup</h3>
+ *
+ *  <p>If a Converter implements the {@link AutoCloseable} interface
+ *  then the {@link AutoCloseable#close()} method will be called when
+ *  the underlying {@link javax.config.Config} is being released.
+ *
  * @author <a href="mailto:rsmeral@apache.org">Ron Smeral</a>
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>

--- a/spec/src/main/asciidoc/configsources.asciidoc
+++ b/spec/src/main/asciidoc/configsources.asciidoc
@@ -132,6 +132,9 @@ public class ExampleYamlConfigSourceProvider
 
 Please note that a single `ConfigSource` should be either registered directly or via a `ConfigSourceProvider`, but never both ways.
 
+=== Cleaning up a ConfigSource
+
+If a `ConfigSource` implements the `java.lang.AutoCloseable` interface  then the `close()` method will be called when the underlying `Config` is being released.
 
 === ConfigSource and Mutable Data
 

--- a/spec/src/main/asciidoc/converters.asciidoc
+++ b/spec/src/main/asciidoc/converters.asciidoc
@@ -102,5 +102,9 @@ For the property injection, Array, List and Set are supported.
 
 myPets will be "dog", "cat", "dog,cat" as an array, List or Set.
 
+=== Cleaning up a Converter
+
+If a `Converter` implements the `java.lang.AutoCloseable` interface  then the `close()` method will be called when the underlying `Config` is being released.
+
 
 <<<

--- a/tck/src/main/java/org/eclipse/configjsr/ConverterTest.java
+++ b/tck/src/main/java/org/eclipse/configjsr/ConverterTest.java
@@ -54,6 +54,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+
 /**
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
@@ -351,4 +352,23 @@ public class ConverterTest extends Arquillian {
     public void testURLConverterBroken() throws Exception {
         URL ignored = config.getValue("tck.config.test.javaconfig.converter.urlvalue.broken", URL.class);
     }
+
+    @Test
+    public void testConverterAutoClose() {
+        DuckConverter duckConverter = new DuckConverter();
+
+        Assert.assertEquals(duckConverter.getCloseCounter(), 0);
+
+        Config config = ConfigProviderResolver.instance().getBuilder()
+            .withConverters(duckConverter)
+            .build();
+
+        // just to trigger the config
+        config.getOptionalValue("somekey", String.class);
+
+        ConfigProviderResolver.instance().releaseConfig(config);
+
+        Assert.assertEquals(duckConverter.getCloseCounter(), 1);
+    }
+
 }

--- a/tck/src/main/java/org/eclipse/configjsr/CustomConfigSourceTest.java
+++ b/tck/src/main/java/org/eclipse/configjsr/CustomConfigSourceTest.java
@@ -19,6 +19,7 @@
  */
 package org.eclipse.configjsr;
 
+import javax.config.spi.ConfigProviderResolver;
 import javax.inject.Inject;
 
 import javax.config.Config;
@@ -36,6 +37,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.eclipse.configjsr.base.AbstractTest.addFile;
+import static org.testng.Assert.assertEquals;
 
 /**
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
@@ -65,6 +67,24 @@ public class CustomConfigSourceTest extends Arquillian {
 
     @Test
     public void testConfigSourceProvider() {
-        Assert.assertEquals(config.getValue("tck.config.test.customDbConfig.key1", String.class), "valueFromDb1");
+        assertEquals(config.getValue("tck.config.test.customDbConfig.key1", String.class), "valueFromDb1");
+    }
+
+    @Test
+    public void testConfigSourceAutoClose() {
+        CustomDbConfigSource customDbConfigSource = new CustomDbConfigSource();
+
+        Assert.assertEquals(customDbConfigSource.getCloseCounter(), 0);
+
+        Config config = ConfigProviderResolver.instance().getBuilder()
+            .withSources(customDbConfigSource)
+            .build();
+
+        // just to trigger the config
+        config.getOptionalValue("somekey", String.class);
+
+        ConfigProviderResolver.instance().releaseConfig(config);
+
+        Assert.assertEquals(customDbConfigSource.getCloseCounter(), 1);
     }
 }

--- a/tck/src/main/java/org/eclipse/configjsr/configsources/CustomDbConfigSource.java
+++ b/tck/src/main/java/org/eclipse/configjsr/configsources/CustomDbConfigSource.java
@@ -27,9 +27,12 @@ import javax.config.spi.ConfigSource;
 /**
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
  */
-public class CustomDbConfigSource implements ConfigSource {
+public class CustomDbConfigSource implements ConfigSource, AutoCloseable {
+
+    private int closeCounter = 0;
 
     private Map<String, String> configValues = new HashMap<>();
+
 
     public CustomDbConfigSource() {
         configValues.put("tck.config.test.customDbConfig.key1", "valueFromDb1");
@@ -66,4 +69,12 @@ public class CustomDbConfigSource implements ConfigSource {
     }
 
 
+    @Override
+    public void close() throws Exception {
+        closeCounter++;
+    }
+
+    public int getCloseCounter() {
+        return closeCounter;
+    }
 }

--- a/tck/src/main/java/org/eclipse/configjsr/converters/DuckConverter.java
+++ b/tck/src/main/java/org/eclipse/configjsr/converters/DuckConverter.java
@@ -24,10 +24,22 @@ import javax.config.spi.Converter;
 /**
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
  */
-public class DuckConverter implements Converter<Duck> {
+public class DuckConverter implements Converter<Duck>, AutoCloseable {
+
+    private int closeCounter = 0;
+
+    public int getCloseCounter() {
+        return closeCounter;
+    }
 
     @Override
     public Duck convert(String value) {
         return new Duck(value);
     }
+
+    @Override
+    public void close() throws Exception {
+        closeCounter++;
+    }
+
 }


### PR DESCRIPTION
ConfigSources and Converters which implement the java.lang.AutoCloseable
interface should get properly closed if the Config is being released.