### PR TITLE
 [#24] Define mapping rule for env variables

### DIFF
--- a/api/src/main/java/javax/config/spi/ConfigSource.java
+++ b/api/src/main/java/javax/config/spi/ConfigSource.java
@@ -42,7 +42,15 @@ import java.util.Set;
  * The default config sources always available by default are:
  * <ol>
  * <li>System properties (ordinal=400)</li>
- * <li>Environment properties (ordinal=300)</li>
+ * <li>Environment properties (ordinal=300)
+ *    <p>Depending on the operating system type, environment variables with '.' are not always allowed. This ConfigSource searches 3 environment variables for a given property name (e.g. {@code "com.ACME.size"}):</p>
+ *        <ol>
+ *            <li>Exact match (i.e. {@code "com.ACME.size"})</li>
+ *            <li>Replace all '.' by '_' (i.e. {@code "com_ACME_size"})</li>
+ *            <li>Replace all '.' by '_' and convert to upper case (i.e. {@code "COM_ACME_SIZE"})</li>
+ *        </ol>
+ *    <p>The first environment variable that is found is returned by this ConfigSource.</p>
+ * </li>
  * <li>/META-INF/javaconfig.properties (ordinal=100)</li>
  * </ol>
  *

--- a/spec/src/main/asciidoc/configsources.asciidoc
+++ b/spec/src/main/asciidoc/configsources.asciidoc
@@ -55,7 +55,20 @@ com.acme.myproject.someserver.url = http://more_important.server/some/endpoint
 A JavaConfig implementation must provide <<ConfigSource,ConfigSources>> for the following data out of the box:
 
 * System properties (default ordinal=400).
+
 * Environment variables (default ordinal=300).
++
+[[default_configsources.env.mapping]]
+Depending on the operating system type, environment variables with `.` are not always allowed.
+This `ConfigSource` searches 3 environment variables for a given property name (e.g. `com.ACME.size`):
+
+  1. Exact match (i.e. `com.ACME.size`)
+  2. Replace all `.` by `_` (i.e. `com_ACME_size`)
+  3. Replace all `.` by `_` and convert to upper case (i.e. `COM_ACME_SIZE`)
+
++
+The first environment variable that is found is returned by this `ConfigSource`.
+
 * A `ConfigSource` for each property file `META-INF/javaconfig.properties` found on the classpath. (default ordinal = 100).
 
 [[custom_configsources]]

--- a/tck/running_the_tck.asciidoc
+++ b/tck/running_the_tck.asciidoc
@@ -49,6 +49,18 @@ To enable the tests in your project you need to add the following dependency to 
 </dependency>
 ----
 
+== Environment Requirements
+
+Some tests are asserting statements related to environment variables.
+The following environment variable and their values must be present in the test runner environment:
+
+* `my_int_property` with the value `45`
+* `MY_BOOLEAN_PROPERTY` with the value `true`
+* `my_string_property` with the value `haha`
+* `MY_STRING_PROPERTY` with the value `woohoo`
+
+See below for an example configuration to provide these environment variables in a Maven pom.xml.
+
 == Declaring the Tests to run
 
 You also need to specify which tests you want to run, e.g. create a file `tck-suite.xml` in your project which contains the following content:
@@ -83,6 +95,13 @@ If you use Apache Maven then the tests are run via the `maven-surefire-plugin`
                 <suiteXmlFiles>
                     <suiteXmlFile>tck-suite.xml</suiteXmlFile>
                 </suiteXmlFiles>
+                <!-- These env variables are required fororg.eclipse.configjsr.CDIPropertyNameMatchingTest -->
+                <environmentVariables>
+                    <my_int_property>45</my_int_property>
+                    <MY_BOOLEAN_PROPERTY>true</MY_BOOLEAN_PROPERTY>
+                    <my_string_property>haha</my_string_property>
+                    <MY_STRING_PROPERTY>woohoo</MY_STRING_PROPERTY>
+                </environmentVariables>
             </configuration>
         </plugin>
     </plugins>

--- a/tck/src/main/java/org/eclipse/configjsr/ArrayConverterTest.java
+++ b/tck/src/main/java/org/eclipse/configjsr/ArrayConverterTest.java
@@ -52,7 +52,7 @@ import org.testng.annotations.Test;
 /**
  * Test the implicit converter handling.
  *
- * @author <a href="mailto:emijiang6@googlemail.com">Mark Struberg</a>
+ * @author <a href="mailto:emijiang6@googlemail.com">Emily Jiang</a>
  */
 public class ArrayConverterTest extends Arquillian {
 

--- a/tck/src/main/java/org/eclipse/configjsr/CDIPlainInjectionTest.java
+++ b/tck/src/main/java/org/eclipse/configjsr/CDIPlainInjectionTest.java
@@ -28,13 +28,13 @@ import static org.hamcrest.Matchers.is;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.config.inject.ConfigProperty;
+import javax.config.spi.ConfigSource;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 import javax.inject.Provider;
 
-import javax.config.inject.ConfigProperty;
-import javax.config.spi.ConfigSource;
 import org.eclipse.configjsr.matchers.AdditionalMatchers;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -42,6 +42,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
 import org.testng.annotations.Test;
 
 /**
@@ -63,10 +64,13 @@ public class CDIPlainInjectionTest extends Arquillian {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
+    @After
+    public void tearDown() {
+        clear_all_property_values();
+    }
+
     @Test
     public void can_inject_simple_values_when_defined() {
-        ensure_all_property_values_are_defined();
-
         SimpleValuesBean bean = getBeanOfType(SimpleValuesBean.class);
 
         assertThat(bean.stringProperty, is(equalTo("text")));

--- a/tck/src/main/java/org/eclipse/configjsr/CDIPropertyNameMatchingTest.java
+++ b/tck/src/main/java/org/eclipse/configjsr/CDIPropertyNameMatchingTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.configjsr;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import javax.config.inject.ConfigProperty;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.spi.CDI;
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Test cases for the statement in configsources.asciidoc#default_configsources.env.mapping
+ *
+ * Prerequisite:
+ * The following environment variables must be set prior to running this test:
+ * "my_int_property" with the value of "45"
+ * "MY_BOOLEAN_PROPERTY" with the value of "true"
+ * "my_string_property" with the value of "haha"
+ * "MY_STRING_PROPERTY" with the value of "woohoo"
+ * @author Emily Jiang
+ */
+public class CDIPropertyNameMatchingTest extends Arquillian {
+
+
+    @Deployment
+    public static Archive deployment() {
+        JavaArchive testJar = ShrinkWrap
+            .create(JavaArchive.class, "CDIPropertyNameMatchingTest.jar")
+            .addClasses(CDIPropertyNameMatchingTest.class, SimpleValuesBean.class)
+            .addAsManifestResource(new StringAsset(
+                    "my.int.property=3"+
+                        "\nmy.string.property=fake"),
+                "javaconfig.properties")
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+            .as(JavaArchive.class);
+
+        WebArchive war = ShrinkWrap
+            .create(WebArchive.class, "CDIPropertyNameMatchingTest.war")
+            .addAsLibrary(testJar);
+        return war;
+    }
+
+    @BeforeClass
+    public void checkSetup() {
+       //check whether the environment variables were populated by the executor correctly
+
+        if (!"45".equals(System.getenv("my_int_property"))) {
+         Assert.fail("Before running this test, the environment variable \"my_int_property\" must be set with the value of 45");
+        }
+        if (!"true".equals(System.getenv("MY_BOOLEAN_PROPERTY"))) {
+            Assert.fail("Before running this test, the environment variable \"MY_BOOLEAN_Property\" must be set with the value of true");
+        }
+        if (!"haha".equals(System.getenv("my_string_property"))) {
+            Assert.fail("Before running this test, the environment variable \"my_string_property\" must be set with the value of haha");
+        }
+        if (!"woohoo".equals(System.getenv("MY_STRING_PROPERTY"))) {
+            Assert.fail("Before running this test, the environment variable \"MY_STRING_PROPERTY\" must be set with the value of woohoo");
+        }
+
+    }
+
+    @Test
+    public void testPropertyFromEnvironmentVariables() {
+        SimpleValuesBean bean = getBeanOfType(SimpleValuesBean.class);
+
+        assertThat(bean.stringProperty, is(equalTo("haha")));
+        assertThat(bean.booleanProperty, is(true));
+        assertThat(bean.intProperty, is(equalTo(45)));
+    }
+
+
+
+    private <T> T getBeanOfType(Class<T> beanClass) {
+        return CDI.current().select(beanClass).get();
+    }
+
+    @Dependent
+    public static class SimpleValuesBean {
+
+        @Inject
+        @ConfigProperty(name="my.string.property")
+        private String stringProperty;
+
+        @Inject
+        @ConfigProperty(name="my.boolean.property")
+        private boolean booleanProperty;
+
+        @Inject
+        @ConfigProperty(name="my.int.property")
+        private int intProperty;
+    }
+  }


### PR DESCRIPTION
* Clarify the env mapping rule with 3 mappings:
1. exact match
1. replace `.` by `_`
1. replace `.` by `_` and upper case

* add CDIPropertyNameMatchingTest to verifies the rules
* update TCK guide to mention required env variables

Signed-off-by: Emily Jiang <emijiang@uk.ibm.com>
Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>