### PR TITLE
#48 Java 9 module support

### DIFF
--- a/api/bnd.bnd
+++ b/api/bnd.bnd
@@ -3,3 +3,4 @@
 Bundle-SymbolicName: javax.config
 Bundle-Name: JavaConfig Bundle
 Bundle-License: Apache License, Version 2.0
+Automatic-Module-Name: javax.config


### PR DESCRIPTION
Using Automatic-Module-Name in MANIFEST.MF

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>