### PR TITLE
refs: #13 of() etc should be used before the ct.

### DIFF
--- a/api/src/main/java/javax/config/spi/Converter.java
+++ b/api/src/main/java/javax/config/spi/Converter.java
@@ -61,12 +61,14 @@ package javax.config.spi;
  * <p>If no explicit Converter and no built-in Converter could be found for a certain type,
  * the {@code Config} provides an <em>Implicit Converter</em>, if</p>
  * <ul>
- *     <li>The target type {@code T} has a Constructor with a String parameter, or</li>
- *     <li>The target type {@code T} has a Constructor with a CharSequence parameter, or</li>
+ *     <li>the target type {@code T} has a {@code static T of(String)} method, or</li>
+ *     <li>the target type {@code T} has a {@code static T of(CharSequence)} method, or</li>
  *     <li>the target type {@code T} has a {@code static T valueOf(String)} method, or</li>
  *     <li>the target type {@code T} has a {@code static T valueOf(CharSequence)} method, or</li>
  *     <li>the target type {@code T} has a {@code static T parse(String)} method, or</li>
  *     <li>the target type {@code T} has a {@code static T parse(CharSequence)} method, or</li>
+ *     <li>The target type {@code T} has a Constructor with a String parameter, or</li>
+ *     <li>The target type {@code T} has a Constructor with a CharSequence parameter, or</li>
  * </ul>
  *
  * <p>The lookup will be done in the order of the above list.

--- a/tck/src/main/java/org/eclipse/configjsr/converters/implicit/ConvTestTypeWCharSequenceOf.java
+++ b/tck/src/main/java/org/eclipse/configjsr/converters/implicit/ConvTestTypeWCharSequenceOf.java
@@ -25,21 +25,21 @@ package org.eclipse.configjsr.converters.implicit;
  *
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
  */
-public class ConvTestTypeWCharSequenceParse {
+public class ConvTestTypeWCharSequenceOf {
     private String val;
 
-    public ConvTestTypeWCharSequenceParse() {
+    public ConvTestTypeWCharSequenceOf() {
     }
 
     /**
      * this ct should actually not be used by our test
      */
-    public ConvTestTypeWCharSequenceParse(CharSequence val) {
+    public ConvTestTypeWCharSequenceOf(CharSequence val) {
         this.val = "wrong" + val;
     }
 
-    public static ConvTestTypeWCharSequenceParse parse(CharSequence val) {
-        ConvTestTypeWCharSequenceParse o = new ConvTestTypeWCharSequenceParse();
+    public static ConvTestTypeWCharSequenceOf of(CharSequence val) {
+        ConvTestTypeWCharSequenceOf o = new ConvTestTypeWCharSequenceOf();
         o.val = val.toString();
         return o;
     }

--- a/tck/src/main/java/org/eclipse/configjsr/converters/implicit/ConvTestTypeWCharSequenceValueOf.java
+++ b/tck/src/main/java/org/eclipse/configjsr/converters/implicit/ConvTestTypeWCharSequenceValueOf.java
@@ -28,6 +28,16 @@ package org.eclipse.configjsr.converters.implicit;
 public class ConvTestTypeWCharSequenceValueOf {
     private String val;
 
+    public ConvTestTypeWCharSequenceValueOf() {
+    }
+
+    /**
+     * this ct should actually not be used by our test
+     */
+    public ConvTestTypeWCharSequenceValueOf(CharSequence val) {
+        this.val = "wrong" + val;
+    }
+
     public static ConvTestTypeWCharSequenceValueOf valueOf(CharSequence val) {
         ConvTestTypeWCharSequenceValueOf o = new ConvTestTypeWCharSequenceValueOf();
         o.val = val.toString();

--- a/tck/src/main/java/org/eclipse/configjsr/converters/implicit/ConvTestTypeWStringOf.java
+++ b/tck/src/main/java/org/eclipse/configjsr/converters/implicit/ConvTestTypeWStringOf.java
@@ -25,22 +25,22 @@ package org.eclipse.configjsr.converters.implicit;
  *
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
  */
-public class ConvTestTypeWCharSequenceParse {
+public class ConvTestTypeWStringOf {
     private String val;
 
-    public ConvTestTypeWCharSequenceParse() {
+    public ConvTestTypeWStringOf() {
     }
 
     /**
      * this ct should actually not be used by our test
      */
-    public ConvTestTypeWCharSequenceParse(CharSequence val) {
+    public ConvTestTypeWStringOf(String val) {
         this.val = "wrong" + val;
     }
 
-    public static ConvTestTypeWCharSequenceParse parse(CharSequence val) {
-        ConvTestTypeWCharSequenceParse o = new ConvTestTypeWCharSequenceParse();
-        o.val = val.toString();
+    public static ConvTestTypeWStringOf of(String val) {
+        ConvTestTypeWStringOf o = new ConvTestTypeWStringOf();
+        o.val = val;
         return o;
     }
 

--- a/tck/src/main/java/org/eclipse/configjsr/converters/implicit/ConvTestTypeWStringParse.java
+++ b/tck/src/main/java/org/eclipse/configjsr/converters/implicit/ConvTestTypeWStringParse.java
@@ -28,6 +28,17 @@ package org.eclipse.configjsr.converters.implicit;
 public class ConvTestTypeWStringParse {
     private String val;
 
+
+    public ConvTestTypeWStringParse() {
+    }
+
+    /**
+     * this ct should actually not be used by our test
+     */
+    public ConvTestTypeWStringParse(String val) {
+        this.val = "wrong" + val;
+    }
+
     public static ConvTestTypeWStringParse parse(String val) {
         ConvTestTypeWStringParse o = new ConvTestTypeWStringParse();
         o.val = val;

--- a/tck/src/main/java/org/eclipse/configjsr/converters/implicit/ConvTestTypeWStringValueOf.java
+++ b/tck/src/main/java/org/eclipse/configjsr/converters/implicit/ConvTestTypeWStringValueOf.java
@@ -28,6 +28,16 @@ package org.eclipse.configjsr.converters.implicit;
 public class ConvTestTypeWStringValueOf {
     private String val;
 
+    public ConvTestTypeWStringValueOf() {
+    }
+
+    /**
+     * this ct should actually not be used by our test
+     */
+    public ConvTestTypeWStringValueOf(String val) {
+        this.val = "wrong" + val;
+    }
+
     public static ConvTestTypeWStringValueOf valueOf(String val) {
         ConvTestTypeWStringValueOf o = new ConvTestTypeWStringValueOf();
         o.val = val;


### PR DESCRIPTION
static valueOf(), of() might hvae the ability to cache known values.
So they should be preferred to the String representation.

Signed-off-by: Mark Struberg <struberg@apache.org>