### PR TITLE
small adjustment in the converter chapter

### DIFF
--- a/spec/src/main/asciidoc/converters.asciidoc
+++ b/spec/src/main/asciidoc/converters.asciidoc
@@ -84,7 +84,7 @@ Array as a class type is supported in the programmatic lookup.
 
 [source, java]
 ----
-String[] myPets = ConfigProvider.getValue("myPet", String[].class);
+String[] myPets = ConfigProvider.getConfig().getValue("myPet", String[].class);
 ----
 
 myPets will be "dog", "cat", "dog,cat" as an array


### PR DESCRIPTION
Signed-off-by: daniel-dos <daniel.dias.analistati@gmail.com>

this PR correct two points,  what I finding in reading the spec .

1 - 
> The escape character is "\". e.g. With
> this config myPets=dog,cat,dog\,cat, the values as an array will be {"dog", "cat", "dog,cat"}.

here the value received in the myPets variable is different from what is presented in SPEC. I believe that here was a small mistake when inserting another quotation mark. in case the variable is filled as follows:

![stringarray](https://user-images.githubusercontent.com/8139890/43939260-2b0d113c-9c3f-11e8-853c-7ff44603910f.png)

2- Failed to add `getConfig` to `ConfigProvider` 

> String[] myPets = ConfigProvider.getValue("myPet", String[].class);