### PR TITLE
Remove asList() asSet(), as() from ConfigAccessor #106

### DIFF
--- a/api/src/main/java/javax/config/Config.java
+++ b/api/src/main/java/javax/config/Config.java
@@ -136,6 +136,17 @@ public interface Config {
      * @return a {@code ConfigAccessor} to access the given propertyName
      */
     ConfigAccessor<String> access(String propertyName);
+    
+    /**
+     * Create a {@link ConfigAccessor} to access the underlying configuration.
+     *
+     * @param <T>  the property type
+     * @param propertyName the property key
+     * @param propertyType
+     *             The type into which the resolve property value should be converted
+     * @return a {@code ConfigAccessor} to access the given propertyName
+     */
+    <T> ConfigAccessor<T> access(String propertyName,Class<T> propertyType);
 
     /**
      * <p>This method can be used to access multiple

--- a/api/src/main/java/javax/config/ConfigAccessor.java
+++ b/api/src/main/java/javax/config/ConfigAccessor.java
@@ -27,11 +27,10 @@
 package javax.config;
 
 
-import javax.config.spi.Converter;
-import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
+import javax.config.spi.Converter;
 
 
 /**
@@ -47,46 +46,6 @@ import java.util.concurrent.TimeUnit;
  * @author <a href="mailto:tomas.langer@oracle.com">Tomas Langer</a>
  */
 public interface ConfigAccessor<T> {
-
-    /**
-     * Sets the type of the configuration entry to the given class and returns this builder.
-     * The default type of a ConfigAccessor is {@code String}.
-     *
-     * <p>Usage:
-     * <pre>
-     * Integer timeout = config.access("some.timeout")
-     *                         .as(Integer.class)
-     *                         .getValue();
-     * </pre>
-     *
-     * Attention: this method should always be the first to be used and might
-     * return a new {@code ConfigAccessor} for the given target clazz.
-     *
-     *
-     * @param clazz The target type
-     * @param <N> The target type
-     * @return This builder as a typed ConfigAccessor
-     */
-    <N> ConfigAccessor<N> as(Class<N> clazz);
-
-    /**
-     * Declare the ConfigAccessor to return a List of the given Type.
-     * When getting value it will be split on each comma (',') character.
-     * If a comma is contained in the values it must get escaped with a preceding backslash (&quot;\,&quot;).
-     * Any backslash needs to get escaped via double-backslash (&quot;\\&quot;).
-     * Note that in property files this leads to &quot;\\\\&quot; as properties escape themselves.
-     *
-     * @return a ConfigAccessor for a list of configured comma separated values
-     */
-    ConfigAccessor<List<T>> asList();
-
-    /**
-     * Declare the ConfigAccessor to return a Set of the given Type.
-     * The notation and escaping rules are the same like explained in {@link #asList()}
-     *
-     * @return a ConfigAccessor for a list of configured comma separated values
-     */
-    ConfigAccessor<Set<T>> asSet();
 
     /**
      * Defines a specific {@link Converter} to be used instead of applying the default Converter resolving logic.

--- a/api/src/main/java/javax/config/spi/Converter.java
+++ b/api/src/main/java/javax/config/spi/Converter.java
@@ -44,7 +44,6 @@ package javax.config.spi;
  *
  * </ul>
 
-<p>
  * <p>Custom Converters will get picked up via the {@link java.util.ServiceLoader} mechanism and and can be registered by
  * providing a file<br>
  * <code>META-INF/services/javax.config.spi.Converter</code><br>

--- a/tck/src/main/java/org/eclipse/configjsr/ConfigAccessorTest.java
+++ b/tck/src/main/java/org/eclipse/configjsr/ConfigAccessorTest.java
@@ -68,8 +68,7 @@ public class ConfigAccessorTest extends Arquillian {
 
     @Test
     public void testGetValueWithDefault() {
-        ConfigAccessor<Integer> cfga = config.access("tck.config.test.javaconfig.configvalue.withdefault.notexisting")
-                .as(Integer.class)
+        ConfigAccessor<Integer> cfga = config.access("tck.config.test.javaconfig.configvalue.withdefault.notexisting",Integer.class)
                 .withDefault(Integer.valueOf(1234));
 
         Assert.assertEquals(cfga.getValue(), Integer.valueOf(1234));
@@ -77,8 +76,7 @@ public class ConfigAccessorTest extends Arquillian {
 
     @Test
     public void testGetValueWithStringDefault() {
-        ConfigAccessor<Integer> cfga = config.access("tck.config.test.javaconfig.configvalue.withdefault.notexisting")
-                .as(Integer.class)
+        ConfigAccessor<Integer> cfga = config.access("tck.config.test.javaconfig.configvalue.withdefault.notexisting",Integer.class)
                 .withStringDefault("1234");
 
         Assert.assertEquals(cfga.getValue(), Integer.valueOf(1234));
@@ -146,70 +144,70 @@ public class ConfigAccessorTest extends Arquillian {
 
     @Test
     public void testIntegerConverter() {
-        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.integer").as(Integer.class).getValue(),
+        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.integer").getValue(),
             Integer.valueOf(1234));
     }
 
     @Test
     public void testLongConverter() {
-        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.long").as(Long.class).getValue(),
+        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.long").getValue(),
             Long.valueOf(1234567890123456L));
     }
 
     @Test
     public void testFloatConverter() {
-        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.float").as(Float.class).getValue(),
+        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.float").getValue(),
             Float.valueOf(12.34f));
     }
 
     @Test
     public void testDoubleonverter() {
-        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.double").as(Double.class).getValue(),
+        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.double").getValue(),
             Double.valueOf(12.34567890123456));
     }
 
     @Test
     public void testBooleanConverter() {
-        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.true").as(Boolean.class).getValue(),
+        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.true").getValue(),
             Boolean.TRUE);
 
-        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.true_uppercase").as(Boolean.class).getValue(),
+        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.true_uppercase").getValue(),
             Boolean.TRUE);
 
-        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.true_mixedcase").as(Boolean.class).getValue(),
+        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.true_mixedcase").getValue(),
             Boolean.TRUE);
 
-        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.false").as(Boolean.class).getValue(),
+        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.false").getValue(),
             Boolean.FALSE);
 
-        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.one").as(Boolean.class).getValue(),
+        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.one").getValue(),
             Boolean.TRUE);
 
-        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.zero").as(Boolean.class).getValue(),
+        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.zero").getValue(),
             Boolean.FALSE);
 
-        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.seventeen").as(Boolean.class).getValue(),
+        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.seventeen").getValue(),
             Boolean.FALSE);
 
-        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.yes").as(Boolean.class).getValue(),
+        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.yes").getValue(),
             Boolean.TRUE);
 
-        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.yes_uppercase").as(Boolean.class).getValue(),
+        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.yes_uppercase").getValue(),
             Boolean.TRUE);
 
-        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.yes_mixedcase").as(Boolean.class).getValue(),
+        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.yes_mixedcase").getValue(),
             Boolean.TRUE);
 
-        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.y").as(Boolean.class).getValue(),
+        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.y").getValue(),
             Boolean.TRUE);
 
-        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.y_uppercase").as(Boolean.class).getValue(),
+        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.y_uppercase").getValue(),
             Boolean.TRUE);
 
-        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.no").as(Boolean.class).getValue(),
+        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.no").getValue(),
             Boolean.FALSE);
 
-        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.no_mixedcase").as(Boolean.class).getValue(),
+        Assert.assertEquals(config.access("tck.config.test.javaconfig.configvalue.boolean.no_mixedcase").getValue(),
             Boolean.FALSE);
 
     }
@@ -243,11 +241,11 @@ public class ConfigAccessorTest extends Arquillian {
         Assert.assertEquals(val2.getDefaultValue(), "abc");
         Assert.assertEquals(val2.getValue(), "abc");
 
-        ConfigAccessor<Integer> vali = config.access(key).as(Integer.class).withDefault(123);
+        ConfigAccessor<Integer> vali = config.access(key,Integer.class).withDefault(123);
         Assert.assertEquals(vali.getDefaultValue(), Integer.valueOf(123));
         Assert.assertEquals(vali.getValue(), Integer.valueOf(123));
 
-        ConfigAccessor<Integer> vali2 = config.access(key).as(Integer.class).withStringDefault("123");
+        ConfigAccessor<Integer> vali2 = config.access(key,Integer.class).withStringDefault("123");
         Assert.assertEquals(vali2.getDefaultValue(), Integer.valueOf(123));
         Assert.assertEquals(vali2.getValue(), Integer.valueOf(123));
 

--- a/tck/src/main/java/org/eclipse/configjsr/DynamicConfigSourceTest.java
+++ b/tck/src/main/java/org/eclipse/configjsr/DynamicConfigSourceTest.java
@@ -74,8 +74,7 @@ public class DynamicConfigSourceTest extends Arquillian {
 
     @Test(enabled = false, description = "disabled for now, Emily and Tomas will come up with a better TCK test")
     public void testValueInvalidationOnConfigChange() throws Exception {
-        ConfigAccessor<Integer> valCfg = config.access(DynamicChangeConfigSource.TEST_ATTRIBUTE)
-            .as(Integer.class)
+        ConfigAccessor<Integer> valCfg = config.access(DynamicChangeConfigSource.TEST_ATTRIBUTE,Integer.class)
             .cacheFor(15, TimeUnit.MINUTES);
 
         // we try to read the same value for 30 consecutive times


### PR DESCRIPTION
Hello , I tried to solve this issue and during refactoring the tests, I did a suggestion a overload of method

ConfigAccessor access(String propertyName);

with

ConfigAccessor access(String propertyName,Class propertyType);

Please , verify if worth it.
Thanks.
Signed-off-by: Breno Pessoa <brenopessoamelo@gmail.com>