### PR TITLE
refs: #52 mark @ConfigProperty as optional

### DIFF
--- a/api/src/main/java/javax/config/inject/ConfigProperty.java
+++ b/api/src/main/java/javax/config/inject/ConfigProperty.java
@@ -37,6 +37,8 @@ import javax.inject.Qualifier;
  * Can be used to annotate injection points of type {@code TYPE}, {@code Optional<TYPE>} or {@code javax.inject.Provider<TYPE>},
  * where {@code TYPE} can be {@code String} and all types which have appropriate converters.
  *
+ * <p>This features is only supported in environments which support {@code @Inject} dependency injection.
+ *
  * <h2>Examples</h2>
  *
  * <h3>Injecting Native Values</h3>

--- a/api/src/main/java/javax/config/spi/ConfigBuilder.java
+++ b/api/src/main/java/javax/config/spi/ConfigBuilder.java
@@ -77,6 +77,8 @@ public interface ConfigBuilder {
     /**
      * Add the specified {@link ConfigSource}.
      *
+     * Attention: If you register the same {@code ConfigSource} instance within multiple {@link Config} then non-portable behaviour results.
+     *
      * @param sources the config sources
      * @return the ConfigBuilder with the configured sources
      */

--- a/api/src/main/java/javax/config/spi/ConfigSource.java
+++ b/api/src/main/java/javax/config/spi/ConfigSource.java
@@ -74,6 +74,8 @@ import java.util.function.Consumer;
  *  then the {@link AutoCloseable#close()} method will be called when
  *  the underlying {@link javax.config.Config} is being released.
  *
+ *  <p> If you register the same {@code ConfigSource} instance within multiple {@link Config} then non-portable behaviour results.
+ *
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
  * @author <a href="mailto:gpetracek@apache.org">Gerhard Petracek</a>
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>

--- a/spec/src/main/asciidoc/configexamples.asciidoc
+++ b/spec/src/main/asciidoc/configexamples.asciidoc
@@ -65,6 +65,7 @@ When specifying the property `myPets=dog,cat,dog\\,cat` in a config source, the 
 === Simple Dependency Injection Example
 
 JavaConfig also provides ways to inject configured values into your beans using the `@Inject` and the `@ConfigProperty` qualifier.
+This feature is only required to be supported in environments which provide dependency injection!
 
 [source, java]
 ----


### PR DESCRIPTION
@ConfigProperty is a EE based feature on top of the SE features.
It is not required to support this annotation in environments which
do not provide Dependency Injection.

Signed-off-by: Mark Struberg <struberg@apache.org>

This fixes #52. We will not do separate specs but only declare that dependency injection only must be supported if running in an environment with DI available.