### PR TITLE
#55 ConfigProviderResolver lazy initialization

### DIFF
--- a/api/src/main/java/javax/config/ConfigProvider.java
+++ b/api/src/main/java/javax/config/ConfigProvider.java
@@ -71,7 +71,10 @@ import javax.config.spi.ConfigProviderResolver;
  * @author <a href="mailto:viktor.klang@gmail.com">Viktor Klang</a>
  */
 public final class ConfigProvider {
-    private static final ConfigProviderResolver INSTANCE = ConfigProviderResolver.instance();
+    
+    private static class LazyHolder { 
+        private static final ConfigProviderResolver INSTANCE = ConfigProviderResolver.instance(); 
+    }
 
     private ConfigProvider() {
     }
@@ -86,7 +89,7 @@ public final class ConfigProvider {
      * @return the config object for the thread context classloader
      */
     public static Config getConfig() {
-        return INSTANCE.getConfig();
+        return LazyHolder.INSTANCE.getConfig();
     }
 
     /**
@@ -100,6 +103,6 @@ public final class ConfigProvider {
      * @return the config for the specified classloader
      */
     public static Config getConfig(ClassLoader classloader) {
-        return INSTANCE.getConfig(classloader);
+        return LazyHolder.INSTANCE.getConfig(classloader);
     }
 }


### PR DESCRIPTION
The `ConfigProviderResolver` should not initialize on just being imported for a variety of reasons.
The major reasons is makes initialization less predictable and bootstrapping more complicated. Performance is also a reason. 
Instead it should be initialized on access just like logging frameworks and many other Java frameworks.